### PR TITLE
specify node engine dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.5",
   "description": "Webpack plugin that makes the process return an error code on failure",
   "main": "index.js",
+  "engines": { "node": ">=0.11.12" },
   "keywords": [
     "webpack"
   ],


### PR DESCRIPTION
webpack-fail-plugin depends on the `process` module's 'beforeExit' event, [which was not introduced until node v0.11.12](https://nodejs.org/api/process.html#process_event_beforeexit).
