### PR TITLE
Add Webpack 2 beta to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "webpack"
   ],
   "peerDependencies": {
-    "webpack": "^1.9.11"
+    "webpack": "^1.9.11 || ^2.1.0-beta"
   },
   "author": "Tiddo Langerak <tiddolangerak@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
This lets people use `failPlugin` with Webpack 2 beta when running npm2
