### PR TITLE
Support Webpack 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "webpack"
   ],
   "peerDependencies": {
-    "webpack": "^1.9.11"
+    "webpack": ">=1.0.0 <3.0.0"
   },
   "author": "Tiddo Langerak <tiddolangerak@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Hello @TiddoLangerak.
I want to webpack-fail-plugin with Webpack 2.x, but I can't install it with npm@2.

```
npm ERR! peerinvalid The package webpack@2.2.1 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer webpack-fail-plugin@1.0.5 wants webpack@^1.9.11
npm ERR! peerinvalid Peer babel-loader@6.2.10 wants webpack@1 || 2 || ^2.1.0-beta || ^2.2.0-rc
```

https://travis-ci.org/pine/is-lo/jobs/201109550

I've try to use webpack-fail-plugin and Webpack 2.x in my computer.
It works fine.

Thank you.