### PR TITLE
Allow webpack 2 and 3 as peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "webpack"
   ],
   "peerDependencies": {
-    "webpack": "^1.9.11"
+    "webpack": "^1.9.11" || "^2" || "^3"
   },
   "author": "Tiddo Langerak <tiddolangerak@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "webpack"
   ],
   "peerDependencies": {
-    "webpack": "^1.9.11" || "^2" || "^3"
+    "webpack": "^1.9.11 || ^2 || ^3"
   },
   "author": "Tiddo Langerak <tiddolangerak@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Despite the changes in webpack 2, this plugin is still needed in some instances (see for example the discussion here: https://github.com/TypeStrong/ts-loader/issues/108).

I've tested it with webpack 2 and 3 and it works as intended.