### PR TITLE
Allow this plugin to be used with webpack 2 & 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
-# DEPRECATED: This is default behaviour in Webpack 2.x, you don't need this plugin anymore.
+# DEPRECATED: This is default behaviour in Webpack 2.x, you probably don't need this plugin anymore.
+
+If you're using Webpack 2+ then you shouldn't need this plugin anymore. Under normal circumstances Webpack
+should already exit with a proper exit code. As such, this plugin does not officially support Webpack 2+.
+
+If you don't get the correct exit code with Webpack 2+ then this is most likely a bug in a plugin you're using, or 
+you're running into a Webpack bug. In either case I strongly recommend to isolate the problem and file issues at the
+appropriate repositories. In the mean time you could try to  use this plugin as a *temporary* workaround. 
+
+# Description
 
 Webpack plugin that will make the process return status code 1 when it finishes with errors in single-run mode.
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "webpack"
   ],
   "peerDependencies": {
-    "webpack": "^1.9.11"
+    "webpack": "^1.9.11" || "^2" || "^3"
   },
   "author": "Tiddo Langerak <tiddolangerak@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "webpack"
   ],
   "peerDependencies": {
-    "webpack": "^1.9.11" || "^2" || "^3"
+    "webpack": "^1.9.11 || ^2 || ^3"
   },
   "author": "Tiddo Langerak <tiddolangerak@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Continued from #14.

This isn't intended to add official support for Webpack 2+, but since multiple people have reported
issues with status codes from Webpack 2+ this might still be useful to workaround webpack/plugin bugs.